### PR TITLE
Make sure that data aligns to block size

### DIFF
--- a/ubireader/ubi_io.py
+++ b/ubireader/ubi_io.py
@@ -80,6 +80,16 @@ class ubi_file(object):
         if ( not end_offset is None ) and ( end_offset > file_size ):
             error(self, 'Fatal', 'End offset larger than file size.')
 
+        # check if data aligns to blocks
+        alignment = self._end_offset % self._block_size
+
+        if ( alignment !=0 ):
+            old_end_offset=self._end_offset
+            self._end_offset = self._end_offset - alignment
+
+            log(self, 'End offset does not align with block size (0x%08X). '
+                      'Truncating %i bytes from file (was: %i bytes, now: %i bytes)'%(self._block_size,alignment,old_end_offset,self._end_offset))
+
         self._fhandle.seek(self._start_offset)
         self._last_read_addr = self._fhandle.tell()
         self.is_valid = True


### PR DESCRIPTION
Added functionality that checks if the input file is aligned to the block size.

Fixes a bug that is triggered if there is something (e.g. a signature) appended to the UBI, which results in bugs like this:
```
read Error: Block ends at 32636928 which is greater than file size 32505908
extract_blocks Fatal: PEB: 248: Bad Read Offset Request
```
