### PR TITLE
fix backward compatibility with image_seq

### DIFF
--- a/ubireader/ubi/block/sort.py
+++ b/ubireader/ubi/block/sort.py
@@ -27,7 +27,7 @@ def by_image_seq(blocks, image_seq):
     Returns:
     List        -- List of block indexes matching image_seq number.
     """
-    return list(filter(lambda block: blocks[block].ec_hdr.image_seq == image_seq, blocks))
+    return list(filter(lambda block: blocks[block].ec_hdr.image_seq == image_seq or image_seq == 0 or blocks[block].ec_hdr.image_seq == 0, blocks))
 
 def by_leb(blocks):
     """Sort blocks by Logical Erase Block number.


### PR DESCRIPTION
Some implementations of UBI don't set image_seq and leave it at 0.
Images dumped from these devices have a mix of valid and zero
image_seq, so we treat the zero as a wildcard.