### PR TITLE
Fix for recent Python 3.x warning that stops script from executing.

### DIFF
--- a/ubireader/debug.py
+++ b/ubireader/debug.py
@@ -34,7 +34,7 @@ def verbose_display(displayable_obj):
         print(displayable_obj.display('\t'))
 
 def error(obj, level, message):
-    if settings.error_action is 'exit':
+    if settings.error_action == 'exit':
         print('{} {}: {}'.format(obj.__name__, level, message))
         if settings.fatal_traceback:
             traceback.print_exc()


### PR DESCRIPTION
Use == instead of is in comparison to be explicit.