### PR TITLE
Use bytearray for greatly improved file processing performance

### DIFF
--- a/ubireader/ubifs/list.py
+++ b/ubireader/ubifs/list.py
@@ -148,7 +148,7 @@ def file_leng(ubifs, inode):
 
 def _process_reg_file(ubifs, inode, path):
     try:
-        buf = b''
+        buf = bytearray()
         if 'data' in inode:
             compr_type = 0
             sorted_data = sorted(inode['data'], key=lambda x: x.key['khash'])
@@ -177,4 +177,4 @@ def _process_reg_file(ubifs, inode, path):
     if inode['ino'].size > len(buf):
         buf += b'\x00' * (inode['ino'].size - len(buf))
         
-    return buf
+    return bytes(buf)

--- a/ubireader/ubifs/output.py
+++ b/ubireader/ubifs/output.py
@@ -165,7 +165,7 @@ def _write_reg_file(path, data):
 
 def _process_reg_file(ubifs, inode, path):
     try:
-        buf = b''
+        buf = bytearray()
         if 'data' in inode:
             compr_type = 0
             sorted_data = sorted(inode['data'], key=lambda x: x.key['khash'])
@@ -194,4 +194,4 @@ def _process_reg_file(ubifs, inode, path):
     if inode['ino'].size > len(buf):
         buf += b'\x00' * (inode['ino'].size - len(buf))
         
-    return buf
+    return bytes(buf)


### PR DESCRIPTION
Using regular immutable bytes object `b''` causes it to be reallocated for every append. This gets incredibly slow when extracting files from images. The change improves performance significantly with minimal code changes by using mutable `bytearray()` object.