### PR TITLE
Fix faulty package name in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='GNU GPL',
     keywords='UBI UBIFS',
 
-    requires=['lzo'],
+    install_requires=['python-lzo'],
     packages = find_packages(),
     scripts=['scripts/ubireader_display_info',
              'scripts/ubireader_extract_files',


### PR DESCRIPTION
The `lzo` dependency in `install_requires` is invalid. The actual dependency is named `python-lzo`.

Merging this upstream would help us with https://github.com/onekey-sec/unblob/issues/501