### PR TITLE
Remove superfluous directory creation

### DIFF
--- a/scripts/ubireader_extract_images
+++ b/scripts/ubireader_extract_images
@@ -75,6 +75,9 @@ if __name__=='__main__':
     parser.add_argument('-f', '--u-boot-fix', action='store_true', dest='uboot_fix',
                       help='Assume blocks with image_seq 0 are because of older U-boot implementations and include them. (default: False)')
 
+    parser.add_argument('--no-basename-subdir', action='store_true', dest='no_basename_subdir',
+                    help='Extract image within output-dir rather than in output-dir/basename(filepath). (default: False)')
+
     parser.add_argument('-o', '--output-dir', dest='outpath',
                         help='Specify output directory path.')
 
@@ -117,7 +120,8 @@ if __name__=='__main__':
     if filetype != UBI_EC_HDR_MAGIC:
         parser.error('File does not look like UBI data.')
 
-    img_name = os.path.basename(path)
+    img_name = "" if args.no_basename_subdir else os.path.basename(path)
+
     if args.outpath:
         outpath = os.path.abspath(os.path.join(args.outpath, img_name))
     else:


### PR DESCRIPTION
ubi-reader scripts creates an output directory named after the input file basename _within_ the extraction directory.

We don't think these directories are required and writing directly to the extraction directory saves some space.

This is what it looks like before:

```
$ ubireader_extract_images ~/unblob/tests/integration/filesystem/ubi/ubi/__input__/fruits.ubi
$ find ubifs-root 
ubifs-root
ubifs-root/fruits.ubi
ubifs-root/fruits.ubi/img-1180426539_vol-apple.ubifs
ubifs-root/fruits.ubi/img-1180426539_vol-data.ubifs
```

This is what it looks like with our fix:

```
$ ubireader_extract_images ~/unblob/tests/integration/filesystem/ubi/ubi/__input__/fruits.ubi
$  find ubifs-root 
ubifs-root
ubifs-root/img-1180426539_vol-apple.ubifs
ubifs-root/img-1180426539_vol-data.ubifs
```

We initially applied this change in our fork of ubi-reader to make the output of unblob cleaner (see https://github.com/onekey-sec/unblob/issues/345). I understand this is kind of an opinionated API change but our team would love to see it land upstream so that we can publish unblob to PyPi (see https://github.com/onekey-sec/unblob/issues/501).

