### PR TITLE
deps: replace python-lzo by lzallright.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,6 @@ An override system is also included, for manually setting certain parameters tha
 This branch will probably remain seperate, as it is meant to be customized to aid in extracting data from problematic images. You can install it with 'python setup.py develop' to make it easier to modify ubi_reader as needed.
 
 
-## Dependencies:
-
-Python 2.7 or 3 with the following packages:
-
-    $ sudo apt-get install liblzo2-dev
-    $ sudo pip install python-lzo
-
-
 ## Installation:
 
 Latest Version

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='GNU GPL',
     keywords='UBI UBIFS',
 
-    install_requires=['python-lzo'],
+    install_requires=['lzallright'],
     packages = find_packages(),
     scripts=['scripts/ubireader_display_info',
              'scripts/ubireader_extract_files',

--- a/ubireader/ubifs/misc.py
+++ b/ubireader/ubifs/misc.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################
 
-import lzo
+from lzallright.lzallright import LZOCompressor as lzo
 import struct
 import zlib
 from ubireader.ubifs.defines import *


### PR DESCRIPTION
We propose to move away from python-lzo because it doesn't have a wheel, so you still need a C compiler and lzo sources.

This commit replace python-lzo with [lzallright](https://github.com/vlaci/lzallright), a Python binding for [lzokay](https://crates.io/crates/lzokay), a Rust based LZO compression/decompression implementation.

This is a move we already did for Jefferson (see https://github.com/onekey-sec/jefferson/pull/14/files) and unblob (see https://github.com/onekey-sec/unblob/pull/573).

The only difference is that ubi-reader will be easier to install :)